### PR TITLE
Add Japanese card size support

### DIFF
--- a/src/Card.css
+++ b/src/Card.css
@@ -157,12 +157,12 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  width: calc(63mm + calc(var(--bleed-edge-width) * 2) + var(--image-container-buffer-width));
-  height: calc(88mm + calc(var(--bleed-edge-width) * 2) + var(--image-container-buffer-width));
+  width: calc(var(--card-width, 63mm) + calc(var(--bleed-edge-width) * 2) + var(--image-container-buffer-width));
+  height: calc(var(--card-height, 88mm) + calc(var(--bleed-edge-width) * 2) + var(--image-container-buffer-width));
 }
 
 .image {
-  width: calc(63mm + var(--image-zoom-width));
+  width: calc(var(--card-width, 63mm) + var(--image-zoom-width));
   object-fit: cover;
 }
 

--- a/src/SettingsForm.tsx
+++ b/src/SettingsForm.tsx
@@ -52,6 +52,17 @@ export const SettingsForm = () => {
   return (
     <form>
       <label>
+        Card Size
+        <select
+          disabled={isRendering}
+          value={settings.cardSize}
+          onChange={handleChange("cardSize")}
+        >
+          <option value="standard">Standard</option>
+          <option value="japanese">Japanese</option>
+        </select>
+      </label>
+      <label>
         Unit
         <select
           disabled={isRendering}

--- a/src/context/SettingsContext.ts
+++ b/src/context/SettingsContext.ts
@@ -12,6 +12,7 @@ export const SettingsSchema = zod.object({
   pageWidth: zod.string(),
   numberOfColumns: zod.string(),
   unit: zod.enum(["in", "mm"]),
+  cardSize: zod.enum(["standard", "japanese"]),
 });
 
 export type Settings = zod.infer<typeof SettingsSchema>;
@@ -27,6 +28,7 @@ export const DEFAULT_SETTINGS = {
   pageWidth: "8.5",
   numberOfColumns: "3",
   unit: "in",
+  cardSize: "standard",
 } as const satisfies Settings;
 
 export type SettingsContextValue = {

--- a/src/context/SettingsProvider.tsx
+++ b/src/context/SettingsProvider.tsx
@@ -51,6 +51,9 @@ export const SettingsProvider = (
   const cssVars = useMemo(() => {
     const guideThickness = value.enableBleedEdge ? Number(value.guidesThickness) : 1
     const imageContainerBuffer = value.enableBleedEdge ? guideThickness : 0
+    const cardWidth = value.cardSize === "japanese" ? "59mm" : "63mm";
+    const cardHeight = value.cardSize === "japanese" ? "86mm" : "88mm";
+
     return {
       "--image-zoom": value.enableBleedEdge ? '6.2mm' : '0mm',
       "--image-container-buffer": `${imageContainerBuffer}px`,
@@ -64,6 +67,8 @@ export const SettingsProvider = (
       "--page-height": `${value.pageHeight}${value.unit}`,
       "--page-width": `${value.pageWidth}${value.unit}`,
       "--grid-columns": value.numberOfColumns,
+      "--card-width": cardWidth,
+      "--card-height": cardHeight,
     } as React.CSSProperties;
   }, [value]);
 

--- a/src/hooks/usePreviewData.ts
+++ b/src/hooks/usePreviewData.ts
@@ -13,12 +13,16 @@ export const usePageLimits = () => {
       parseFloat(settings.pageHeight) * (settings.unit === "in" ? 25.4 : 1);
     const guidesThickness = parseFloat(settings.guidesThickness) * 0.265; // convert px to mm
     const bleedEdge = parseFloat(settings.bleedEdge); // mm
-    
+
+    // Define card height constants
+    const CARD_HEIGHT = {
+      standard: 88, // Standard card height in mm
+      japanese: 86, // Japanese card height in mm
+    };
+
     // Adjust card height based on card size
     const cardHeight =
-      settings.cardSize === "japanese"
-        ? 86 + 2 * bleedEdge + guidesThickness // Japanese card height
-        : 88 + 2 * bleedEdge + guidesThickness; // Standard card height
+      CARD_HEIGHT[settings.cardSize] + 2 * bleedEdge + guidesThickness;
 
     return Math.floor(pageHeight / cardHeight);
   }, [settings]);
@@ -40,7 +44,7 @@ export const usePageLimits = () => {
     cardsPerPage,
     maxPages,
   };
-}
+};
 
 export const usePreviewData = () => {
   const { images } = useContext(ImagesContext);

--- a/src/hooks/usePreviewData.ts
+++ b/src/hooks/usePreviewData.ts
@@ -13,8 +13,13 @@ export const usePageLimits = () => {
       parseFloat(settings.pageHeight) * (settings.unit === "in" ? 25.4 : 1);
     const guidesThickness = parseFloat(settings.guidesThickness) * 0.265; // convert px to mm
     const bleedEdge = parseFloat(settings.bleedEdge); // mm
-    // card height is 88mm + 2 * bleedEdge + guidesThickness
-    const cardHeight = 88 + 2 * bleedEdge + guidesThickness; // mm
+    
+    // Adjust card height based on card size
+    const cardHeight =
+      settings.cardSize === "japanese"
+        ? 86 + 2 * bleedEdge + guidesThickness // Japanese card height
+        : 88 + 2 * bleedEdge + guidesThickness; // Standard card height
+
     return Math.floor(pageHeight / cardHeight);
   }, [settings]);
 

--- a/src/workers/pdf-worker.ts
+++ b/src/workers/pdf-worker.ts
@@ -23,6 +23,7 @@ type CardData = {
         isFirstColumn: boolean;
         isLastColumn: boolean;
     };
+    cardSize: Settings['cardSize'];
     guides: {
       enabled: boolean;
       thickness: number;
@@ -78,6 +79,9 @@ function addImage(cardData: CardData) {
     guides,
   } = cardData;
 
+  const adjustedContainerWidth = containerWidth * scaleX;
+  const adjustedContainerHeight = containerHeight * scaleY;
+
   // Add image to PDF
   if (imageDataUrl) {
     let detectedPdfFormat = "PNG"; // default
@@ -103,8 +107,8 @@ function addImage(cardData: CardData) {
       detectedPdfFormat,
       pdfX,
       pdfY,
-      containerWidth * scaleX,
-      containerHeight * scaleY,
+      adjustedContainerWidth,
+      adjustedContainerHeight,
       undefined,
       "FAST"
     );
@@ -112,8 +116,8 @@ function addImage(cardData: CardData) {
 
   // Add guides if needed
   if (guides && guides.enabled) {
-    const pdfContainerWidth = containerWidth * scaleX;
-    const pdfContainerHeight = containerHeight * scaleY;
+    const pdfContainerWidth = adjustedContainerWidth;
+    const pdfContainerHeight = adjustedContainerHeight;
 
     // Set line color and style
     pdf.setDrawColor(0, 0, 0); // Black for guides


### PR DESCRIPTION
The app is great for Standard size TCGs like Magic and Elestrals. I wanted to extend the support to Japanese size TCGs like Yu-Gi-Oh!, Cardfight!! Vanguard, etc. I was able to add a drop down to select whichever card size a user wants to make proxies for.

Here's an example image:
<img width="1121" height="852" alt="image" src="https://github.com/user-attachments/assets/434aebb1-5c58-4f21-9be7-4012bf9d6442" />

Works great and I printed some too:
<img width="688" height="913" alt="image" src="https://github.com/user-attachments/assets/57f8082e-334d-4a02-9cb3-143f40ee8af6" />

